### PR TITLE
enable positioning

### DIFF
--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -368,8 +368,8 @@ def batch_prepare_tiltseries(
 )
 @click.option('--skip-positioning',
               is_flag=True,
-              default = True,
-              show_default = True,
+              default=False,
+              show_default=True,
               help='Skip tomogram positioning. Useful for STA.')
 @click.option(
     "--do-evn-odd",


### PR DESCRIPTION
The default setting already disables positioning, so currently it is not possible to do automatic positioning.
Changing default to False, gives the correct behavior.