### PR TITLE
Fix install nogitlfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.mrc.mdoc filter=lfs diff=lfs merge=lfs -text
-*.mrc filter=lfs diff=lfs merge=lfs -text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ cryocare = [
 dev = [
     "pytest",
     "ruff",
+    "tomotools-testfiles-lfs@git+https://github.com/tomotools/tomotools-testfiles-lfs.git"
 ]
 
 [project.scripts]

--- a/tomotools/tests/testfiles/UZH_K2_2111_bin8.mrc
+++ b/tomotools/tests/testfiles/UZH_K2_2111_bin8.mrc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:291788f3ca9c77328571d9e27682f23ee5c1443bc21e99f1d380b33e6cd8e641
-size 13810098

--- a/tomotools/tests/testfiles/UZH_K2_2111_bin8.mrc.mdoc
+++ b/tomotools/tests/testfiles/UZH_K2_2111_bin8.mrc.mdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:277b218ed766117fdfdb33a63f86c19470f2424f23b9225433df7ced895461f6
-size 21400

--- a/tomotools/tests/testfiles/UZH_K2_2207_bin8.mrc
+++ b/tomotools/tests/testfiles/UZH_K2_2207_bin8.mrc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03e6e50939358add1a4e5b9ccd06f9f37a3ebf6d5b9b9392117fb37965af0792
-size 12919190

--- a/tomotools/tests/testfiles/UZH_K2_2207_bin8.mrc.mdoc
+++ b/tomotools/tests/testfiles/UZH_K2_2207_bin8.mrc.mdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f96b4e27276a7f9e59c2cc75824838ec66d2773c4f50cf80edfe0de43f3b3c40
-size 17685

--- a/tomotools/tests/testfiles/UZH_K3_2207_bin8.mrc
+++ b/tomotools/tests/testfiles/UZH_K3_2207_bin8.mrc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fad45cc6d8ce2fb014cccf18c1ecc06cc5c368315727d33ec106496abe7223c1
-size 51610624

--- a/tomotools/tests/testfiles/UZH_K3_2207_bin8.mrc.mdoc
+++ b/tomotools/tests/testfiles/UZH_K3_2207_bin8.mrc.mdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3fa82f1aa8a4b08ec1d1f4718a5c9681c6559ac4d295c2137bfdd6c167c9c91
-size 29416

--- a/tomotools/tests/testfiles/UniHD_K3_2206_bin8.mrc
+++ b/tomotools/tests/testfiles/UniHD_K3_2206_bin8.mrc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7023914b21e6cad872df56ed54e72b02dba7b2890854166b861c966f72d78f1
-size 30229668

--- a/tomotools/tests/testfiles/UniHD_K3_2206_bin8.mrc.mdoc
+++ b/tomotools/tests/testfiles/UniHD_K3_2206_bin8.mrc.mdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a674b165034a3891d1574a9f75060d4a9c60aacde02ec3f3fcf9d8d6eb087768
-size 30864

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -305,11 +305,11 @@ def align_with_areTomo(
     # AreTomo somehow is inconsistent in naming .aln files
     if ts.path.suffix == '.st' and path.isfile(f"{ts.path}.aln"):
         os.rename(f"{ts.path}.aln", aln_file)
-    
+
     # Keep compatibility with AreTomo < 1.3, which output the file
     if not path.isfile(ali_stack.with_suffix('.tlt')):
         aln_to_tlt(aln_file)
-        
+
     if do_evn_odd and ts.is_split:
         ali_stack_evn = ts.evn_path.with_name(f"{ts.path.stem}_ali_EVN.mrc")
         ali_stack_odd = ts.odd_path.with_name(f"{ts.path.stem}_ali_ODD.mrc")


### PR DESCRIPTION
the mrc stacks are now only installed in the [dev] version, as they were causing issues if `git-lfs` was not installed.