### PR TITLE
initial implementation of tomotools reconstruct-3dctf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ tomotools [subcommand] --help
 - **aretomo2warp**: Takes a list of directories with AreTomo-aligned tiltseries or a file listing them and prepares everything for Warp.
 - **fit-ctf**: Run imod ctfplotter on a set of tiltseries and save results to their folder.
 - **merge-dboxes**: Very beta, merges Dynamo DBoxes.
+- **reconstruct-3dctf**: Perform reconstruction using imods `ctf3d` function.
 
 ### Other
 - **semnavigator**: Display SerialEM navigator files to find back you tomogram positions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "Tomotools"
 description = "Scripts to make cryo-electron tomography a bit easier."
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.3"
 
 requires-python = ">=3.7"
 license = {text = "None so far"}

--- a/tomotools/__init__.py
+++ b/tomotools/__init__.py
@@ -8,7 +8,7 @@ from .commands import commands
 @click.group()
 def tomotools():
     """Scripts for cryo-ET data processing."""
-    click.echo("Tomotools version 0.3.1 \n")
+    click.echo("Tomotools version 0.3.3 \n")
 
 
 for command in commands:

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -197,7 +197,10 @@ def reconstruct_3dctf(thickness, bin, input_files):
         # Link reconstruction back to main dir, in case AreTomo alignments are used
         if aretomo:
             os.symlink(rec.path.absolute(),
-                       ts_in.parent / f'{ts_in.path.name}_3dctf_bin{bin}.mrc')
+                       ts_in.path.parent / f'{ts_in.path.stem}_3dctf_bin{bin}.mrc')
+        else:
+            os.rename(rec.path.absolute(), 
+                      ts_in.path.parent / f'{ts_in.path.stem}_3dctf_bin{bin}.mrc')
 
         print('\n')
 


### PR DESCRIPTION
Hi, 

I wrote an initial implementation of a command `tomotools reconstruct-3dctf`, which uses `ctf3d` in imod and accepts both aretomo and imod alignments. I decided to put it into a different command rather than as an extension to the normal `reconstruct` command, as that one is already quite overloaded. 
Anyways, I guess 3D CTF reconstruction is a bit more specialized and only needed to prepare for STA, but I'm also willing to change this. 

As a consequence, `reconstruct-3dctf` right now is very simple and only takes three inputs:
- the total thickness in unbinned pixels
- the desired binning level
- one or more input files or the folders containing them, where alignment files from imod (`.xf`) or AreTomo (`.aln`) are already present. If both are present, imod alignments are preferred, but I'd consider introducing a flag to force AreTomo if required. 

@McHaillet could you check whether works for you and whether it has all the features one may need?

Best,
Benedikt