### PR TITLE
Prepare files for TomoTwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ tomotools [subcommand] --help
 ### Subtomogram Averaging Preparation
 - **imod2warp**: Takes a list of imod directories or a file listing them and prepares everything for Warp.
 - **aretomo2warp**: Takes a list of directories with AreTomo-aligned tiltseries or a file listing them and prepares everything for Warp.
+- **imod2tomotwin**: Takes a list of imod directories and reconstructs for TomoTwin picking.
+- **aretomo2tomotwin**: Takes a list of AreTomo directories and reconstructs for TomoTwin picking.
 - **fit-ctf**: Run imod ctfplotter on a set of tiltseries and save results to their folder.
 - **merge-dboxes**: Very beta, merges Dynamo DBoxes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "Tomotools"
 description = "Scripts to make cryo-electron tomography a bit easier."
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 requires-python = ">=3.7"
 license = {text = "None so far"}

--- a/tomotools/__init__.py
+++ b/tomotools/__init__.py
@@ -8,7 +8,7 @@ from .commands import commands
 @click.group()
 def tomotools():
     """Scripts for cryo-ET data processing."""
-    click.echo("Tomotools version 0.3.1 \n")
+    click.echo("Tomotools version 0.3.2 \n")
 
 
 for command in commands:

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -1,13 +1,16 @@
+import math
 import os
 from os import path
+from pathlib import Path
 
 import click
 
-from tomotools.utils import sta_util
+from tomotools.utils import sta_util, tiltseries
 from tomotools.utils.tiltseries import (
     convert_input_to_TiltSeries,
     run_ctfplotter,
 )
+from tomotools.utils.tomogram import Tomogram
 
 
 @click.command()
@@ -136,3 +139,85 @@ def aretomo2warp(batch_input, name, input_files, project_dir):
 
         print(f"Warp files prepared for {ts.path.name}. \n")
 
+
+@click.command()
+@click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,
+              help="Read input files as text, each line is a tiltseries (folder)")
+@click.option('-d', '--thickness', default=3000, show_default=True,
+              help="Tomogram thickness in unbinned pixels.")
+@click.option('--uid', default='imod', show_default=True,
+              help="Unique identifier to tell apart tomograms from several sessions.")
+@click.argument('input_files', nargs=-1)
+@click.argument('tomotwin_dir', nargs=1)
+def imod2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
+    """Prepare for TomoTwin picking.
+
+    Takes as input several tiltseries (folders) or a file listing them (with -b),
+    obtained after processing with tomotools batch-prepare-tiltseries
+    and reconstructed in subdirectories using imod.
+
+    Will output tomograms as desired by TomoTwin in the specified project folder,
+    subfolder "tomo".
+
+    Provide the unbinned thickness, and a unique identifier for this session.
+    UID will be put in from of name, e.g. 230105_TS_01.mrc.
+    """
+    ts_list = sta_util.batch_parser(input_files, batch)
+
+    tomotwin_dir = Path(tomotwin_dir)
+    tomo_dir = tomotwin_dir / "tomo"
+
+    if not path.isdir(tomo_dir):
+        os.mkdir(tomo_dir)
+
+    for ts in ts_list:
+
+        # bin to about 10 Apix, prefer round binning to avoid artifacts
+        binning = math.ceil(10 / ts.angpix / 2) * 2
+
+        ts_ali = tiltseries.align_with_imod(ts, True, False, binning=binning)
+
+        rec = Tomogram.from_tiltseries(ts_ali, bin=1, sirt=0,
+                                       thickness=round(thickness/binning),
+                                       convert_to_byte=False)
+
+        unique_name = f'{uid}_{ts.path.parent.name}.mrc'
+
+        os.symlink(rec.path.absolute(), tomo_dir / unique_name)
+
+@click.command()
+@click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,
+              help="Read input files as text, each line is a tiltseries (folder)")
+@click.option('-d', '--thickness', default=3000, show_default=True,
+              help="Tomogram thickness in unbinned pixels.")
+@click.option('--uid', default='aretomo', show_default=True,
+              help="Unique identifier to tell apart tomograms from several sessions.")
+@click.argument('input_files', nargs=-1)
+@click.argument('tomotwin_dir', nargs=1)
+def aretomo2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
+    """Prepare for TomoTwin picking.
+
+    Takes as input several tiltseries (folders) or a file listing them (with -b),
+    obtained after processing with tomotools batch-prepare-tiltseries
+    and reconstructed in subdirectories using AreTomo.
+
+    Will output tomograms as desired by TomoTwin in the specified project folder,
+    subfolder "tomo".
+
+    Provide the unbinned thickness, and a unique identifier for this session.
+    UID will be put in from of name, e.g. 230105_TS_01.mrc.
+    """
+    # Get input files
+    ts_list = sta_util.batch_parser(input_files, batch)
+
+    # Process aretomo -> imod
+    print(f'Found {len(ts_list)} TiltSeries to work on. \n')
+
+    ts_imodlike = []
+
+    for ts in ts_list:
+        print(f"Now working on {ts.path.name}")
+        ts_imodlike.append(sta_util.aretomo_export(ts))
+
+    # Process as normal imod-aligned TS
+    imod2tomotwin(False, thickness, uid, ts_imodlike, tomotwin_dir)

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -149,7 +149,7 @@ def aretomo2warp(batch_input, name, input_files, project_dir):
               help="Unique identifier to tell apart tomograms from several sessions.")
 @click.argument('input_files', nargs=-1)
 @click.argument('tomotwin_dir', nargs=1)
-def imod2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
+def imod2tomotwin(batch_input, thickness, uid, input_files, tomotwin_dir):
     """Prepare for TomoTwin picking.
 
     Takes as input several tiltseries (folders) or a file listing them (with -b),
@@ -162,7 +162,7 @@ def imod2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
     Provide the unbinned thickness, and a unique identifier for this session.
     UID will be put in from of name, e.g. 230105_TS_01.mrc.
     """
-    ts_list = sta_util.batch_parser(input_files, batch)
+    ts_list = sta_util.batch_parser(input_files, batch_input)
 
     tomotwin_dir = Path(tomotwin_dir)
     tomo_dir = tomotwin_dir / "tomo"
@@ -194,7 +194,7 @@ def imod2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
               help="Unique identifier to tell apart tomograms from several sessions.")
 @click.argument('input_files', nargs=-1)
 @click.argument('tomotwin_dir', nargs=1)
-def aretomo2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
+def aretomo2tomotwin(batch_input, thickness, uid, input_files, tomotwin_dir):
     """Prepare for TomoTwin picking.
 
     Takes as input several tiltseries (folders) or a file listing them (with -b),
@@ -208,7 +208,7 @@ def aretomo2tomotwin(batch, thickness, uid, input_files, tomotwin_dir):
     UID will be put in from of name, e.g. 230105_TS_01.mrc.
     """
     # Get input files
-    ts_list = sta_util.batch_parser(input_files, batch)
+    ts_list = sta_util.batch_parser(input_files, batch_input)
 
     # Process aretomo -> imod
     print(f'Found {len(ts_list)} TiltSeries to work on. \n')

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -216,6 +216,6 @@ def tomotwin_prep(tomotwin_dir, ts_list, thickness, uid):
                                                 thickness=round(thickness/binning),
                                                 convert_to_byte=False)
 
-        unique_name = f'{uid}_{ts.path.parent.name}.mrc'
+        unique_name = f'{uid}_{ts.path.parent.absolute().name}.mrc'
 
         os.symlink(rec.path.absolute(), tomo_dir / unique_name)


### PR DESCRIPTION
This PR contains commands `aretomo2tomowin` and `imod2tomotwin`, which are analogous to the `[imod/aretomo]2warp` commands and reconstruct tomograms in the convention that `tomotwin-cryoet` likes to have as an input. 