### PR TITLE
Add warp-copy command, add --prefix to imod2warp

### DIFF
--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -27,20 +27,21 @@ def fit_ctf(input_files):
     for ts in tiltseries:
         run_ctfplotter(ts, True)
 
-
 @click.command()
+@click.option('--aretomo/--imod', is_flag=True, default=False, show_default=True,
+             help="Whether tomos are aretomo or imod reconstructions")
 @click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,
               help="Read input files as text, each line is a tiltseries (folder)")
 @click.option('-p', '--prefix', default='',
               help="Prefix files to avoid name collisions")
 @click.argument('input_files', nargs=-1)
 @click.argument('project_dir', nargs=1)
-def imod2warp(batch_input, prefix, input_files, project_dir):
+def tomo2warp(aretomo, batch_input, prefix, input_files, project_dir):
     """Prepares Warp/M project.
 
     Takes as input several tiltseries (folders) or a file listing them (with -b),
     obtained after processing with tomotools batch-prepare-tiltseries
-    and reconstructed in subdirectories using imod.
+    and reconstructed in subdirectories using AreTomo.
 
     Provide the root folder for the averaging project and a name for this export.
     This will be the Warp working directory. Both will be created if non-existent.
@@ -64,73 +65,17 @@ def imod2warp(batch_input, prefix, input_files, project_dir):
     (project_dir / 'imod').mkdir(exist_ok=True)
     (project_dir / 'mdoc').mkdir(exist_ok=True)
 
-    # Parse input files
     ts_list = sta_util.batch_parser(input_files, batch_input)
-
     print(f'Found {len(ts_list)} TiltSeries to work on. \n')
-
     for ts in ts_list:
-        print(f"Now working on {ts.path.name}")
-        sta_util.make_warp_dir(ts, project_dir, prefix=prefix, imod=True)
-        print(f"Warp files prepared for {ts.path.name}. \n")
-
-
-@click.command()
-@click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,
-              help="Read input files as text, each line is a tiltseries (folder)")
-@click.option('-n', '--name', default='warp', show_default=True,
-              help="Warp working directory will be created as project_dir/name.")
-@click.argument('input_files', nargs=-1)
-@click.argument('project_dir', nargs=1)
-def aretomo2warp(batch_input, name, input_files, project_dir):
-    """Prepares Warp/M project.
-
-    Takes as input several tiltseries (folders) or a file listing them (with -b),
-    obtained after processing with tomotools batch-prepare-tiltseries
-    and reconstructed in subdirectories using AreTomo.
-
-    Provide the root folder for the averaging project and a name for this export.
-    This will be the Warp working directory. Both will be created if non-existent.
-
-    Suggested structure is something like this:
-
-    project_dir/
-        ./warpdir1/
-        ./warpdir2/
-        ./warpdir3/
-        ./relion/
-        ./m/
-
-    """
-    out_dir = path.join(project_dir, name)
-
-    if not path.isdir(project_dir):
-        os.mkdir(project_dir)
-
-    if path.isdir(out_dir):
-        input(f'Exporting to existing directory {out_dir}. Continue?')
-
-    else:
-        os.mkdir(out_dir)
-        os.mkdir(path.join(out_dir, 'imod'))
-        os.mkdir(path.join(out_dir, 'mdoc'))
-        print(f"Created Warp folder at {out_dir}.")
-
-    ts_list = sta_util.batch_parser(input_files, batch_input)
-
-    print(f'Found {len(ts_list)} TiltSeries to work on. \n')
-
-    for ts in ts_list:
-        print(f"Now working on {ts.path.name}")
-
-        ts_out_imod = sta_util.aretomo_export(ts)
-
-        print(f'Performed AreTomo export of {ts.path.stem}.')
-
-        sta_util.make_warp_dir(ts_out_imod, out_dir)
-
-        print(f"Warp files prepared for {ts.path.name}. \n")
-
+            print(f"Now working on {ts.path.name}")
+            if aretomo:
+                ts_out_imod = sta_util.aretomo_export(ts)
+                print(f'Performed AreTomo export of {ts.path.stem}.')
+                sta_util.make_warp_dir(ts_out_imod, project_dir, prefix=prefix)
+            else:
+                sta_util.make_warp_dir(ts, project_dir, prefix=prefix, imod=True)
+            print(f"Warp files prepared for {ts.path.name}. \n")
 
 @click.command()
 @click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -228,7 +228,11 @@ def warp_copy(input_project: os.PathLike, copy_name: str):
 
     n_links, n_copies = 0, 0
     for child in input_project.iterdir():
-        if child.is_dir() or (
+        if child.is_symlink():
+            link = output_dir / child.name
+            link.symlink_to(child.readlink())
+            n_links += 1
+        elif child.is_dir() or (
             child.is_file() and child.suffix in ['.mrc', '.st', '.tif', '.tiff']
         ):
             link = output_dir / child.name

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -31,11 +31,11 @@ def fit_ctf(input_files):
 @click.command()
 @click.option('-b', '--batch-input', is_flag=True, default=False, show_default=True,
               help="Read input files as text, each line is a tiltseries (folder)")
-@click.option('-n', '--name', default='warp', show_default=True,
-              help="Warp working directory will be created as project_dir/name.")
+@click.option('-p', '--prefix', default='',
+              help="Prefix files to avoid name collisions")
 @click.argument('input_files', nargs=-1)
 @click.argument('project_dir', nargs=1)
-def imod2warp(batch_input, name, input_files, project_dir):
+def imod2warp(batch_input, prefix, input_files, project_dir):
     """Prepares Warp/M project.
 
     Takes as input several tiltseries (folders) or a file listing them (with -b),
@@ -55,19 +55,14 @@ def imod2warp(batch_input, name, input_files, project_dir):
         ./m/
 
     """
-    out_dir = path.join(project_dir, name)
-
-    if not path.isdir(project_dir):
-        os.mkdir(project_dir)
-
-    if path.isdir(out_dir):
-        input(f'Exporting to existing directory {out_dir}. Continue?')
-
+    project_dir: Path = Path(project_dir)
+    if project_dir.is_dir():
+        input(f'Exporting to existing directory {project_dir}. Continue?')
     else:
-        os.mkdir(out_dir)
-        os.mkdir(path.join(out_dir, 'imod'))
-        os.mkdir(path.join(out_dir, 'mdoc'))
-        print(f"Created Warp folder at {out_dir}.")
+        project_dir.mkdir()
+        print(f"Created Warp folder at {project_dir}.")
+    (project_dir / 'imod').mkdir(exist_ok=True)
+    (project_dir / 'mdoc').mkdir(exist_ok=True)
 
     # Parse input files
     ts_list = sta_util.batch_parser(input_files, batch_input)
@@ -76,9 +71,7 @@ def imod2warp(batch_input, name, input_files, project_dir):
 
     for ts in ts_list:
         print(f"Now working on {ts.path.name}")
-
-        sta_util.make_warp_dir(ts, out_dir, imod = True)
-
+        sta_util.make_warp_dir(ts, project_dir, prefix=prefix, imod=True)
         print(f"Warp files prepared for {ts.path.name}. \n")
 
 

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -149,7 +149,7 @@ def make_warp_dir(ts: TiltSeries, project_dir: Path, prefix='', imod: bool = Fal
             Path(subframelist[i]).name
 
     if "path" in mdoc:
-        mdoc["path"] = prefix + mdoc["path"]
+        mdoc["path"] = prefix + str(mdoc["path"])
     if "ImageFile" in mdoc:
         mdoc["ImageFile"] = prefix + mdoc["ImageFile"]
     mdoc = mdocfile.downgrade_DateTime(mdoc)


### PR DESCRIPTION
This pull request has two features which I would like to hear your opinion on:

### warp-copy command

I don't know how you handle making backups of your Warp working directories, but I was told it's important. Also, I find it convenient to have some sort of "version control" of my Warp dirs, like different kind of subtomo reconstructions.
warp-copy essentially copies an entire Warp directory. However, it only _actually_ copies metadata files. All directories (subtomo/reconstruction/imod/mdoc/...) and all image files are linked, making this process very fast. On Windows, the files appear normal (at least for me, I use a Samba network mount). What I don't know is what happens if you delete a linked directory on Windows, that remains to be tested.

### imod2warp --prefix

I wanted to merge two datasets which had overlapping tilt-series filenames, so I added the --prefix option to imod2warp. It just prepends the given prefix to all tilt-series files. So far this has been working well, though I had weird out-of-memory bugs in Relion when I prefixed tilt-series with the date only. No idea if this is a coincidence, remains to be tested.
Also, I removed the --name option. If you like to keep it I can of course add it again. I though it's easier to just pass the output directory.