### PR TITLE
AreTomo2/MotionCor3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tomotools [subcommand] --help
 
 ## Dependencies
 `tomotools` depends on commands from MotionCor2 or MotionCor3, IMOD, and AreTomo 1.X or AreTomo2 for full functionality. IMOD should be in PATH. 
-MotionCor2/3 and AreTomo2/3 can either be in PATH as `motioncor2` /  `motioncor3` or `aretomo` / `aretomo2` respectively, or set using the envar `MOTIONCOR2_EXECUTABLE` or `ARETOMO_EXECUTABLE`.
+MotionCor2/3 and AreTomo2/3 can either be in PATH as `MotionCor2` /  `MotionCor3` or `AreTomo` / `AreTomo2` respectively, or set using the envar `MOTIONCOR_EXECUTABLE` or `ARETOMO_EXECUTABLE`.
 
 ## Installation
 We suggest installing tomotools into its own conda / mamba environment. 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ tomotools [subcommand] --help
 - **restore-frames**: Restore SubFramePath to mdoc of tiltseries preprocessed with tomotools < 0.4. 
 
 ## Dependencies
-`tomotools` depends on commands from MotionCor2, IMOD, and AreTomo for full functionality. IMOD should be in PATH. 
-MotionCor2 and AreTomo can either be in PATH as `motioncor2` or `aretomo` respectively, or set using the envar `MOTIONCOR2_EXECUTABLE` or `ARETOMO_EXECUTABLE`.
+`tomotools` depends on commands from MotionCor2 or MotionCor3, IMOD, and AreTomo 1.X or AreTomo2 for full functionality. IMOD should be in PATH. 
+MotionCor2/3 and AreTomo2/3 can either be in PATH as `motioncor2` /  `motioncor3` or `aretomo` / `aretomo2` respectively, or set using the envar `MOTIONCOR2_EXECUTABLE` or `ARETOMO_EXECUTABLE`.
 
 ## Installation
 We suggest installing tomotools into its own conda / mamba environment. 

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -520,6 +520,7 @@ def reconstruct(
         # If previous is passed, respect --imod flag.
         # Otherwise, use AreTomo.
 
+        #TODO: bin during alignment
         if previous and imod:
             tiltseries_ali = align_with_imod(tiltseries, previous, do_evn_odd)
         else:
@@ -590,6 +591,8 @@ def reconstruct(
             tomo_pitch.path.unlink(missing_ok=True)
 
         # Perform final reconstruction
+        
+        # TODO: don't bin here anymore!
         Tomogram.from_tiltseries(tiltseries_dosefiltered,
                                  bin=bin,
                                  thickness=thickness,

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -591,7 +591,7 @@ def reconstruct(
             tomo_pitch.path.unlink(missing_ok=True)
 
         # Perform final reconstruction
-        
+
         # TODO: don't bin here anymore!
         Tomogram.from_tiltseries(tiltseries_dosefiltered,
                                  bin=bin,

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -257,7 +257,7 @@ def preprocess(
                                 output_dir])
             continue
 
-        print(f'Frames were found for {input_file.path}, will run align using MC2.')
+        print(f'Frames were found for {input_file.path}, will run MotionCor.')
 
         # Get rotation and flip of Gain reference from mdoc file property
         mcrot, mcflip = None, None

--- a/tomotools/utils/comfile.py
+++ b/tomotools/utils/comfile.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from tomotools.utils.tiltseries import TiltSeries
 
 
@@ -82,7 +84,7 @@ def fake_ctfcom(ts: TiltSeries, binning: int):
 
 
 def fix_tiltcom(ts: TiltSeries, thickness: int, fsirt: int, bin: int,
-                fullimage: []):
+                fullimage: List[int, int]):
     """
     Make sure tilt.com file has the right parameters.
 

--- a/tomotools/utils/comfile.py
+++ b/tomotools/utils/comfile.py
@@ -84,7 +84,7 @@ def fake_ctfcom(ts: TiltSeries, binning: int):
 
 
 def fix_tiltcom(ts: TiltSeries, thickness: int, fsirt: int, bin: int,
-                fullimage: List[int, int]):
+                fullimage: List[int]):
     """
     Make sure tilt.com file has the right parameters.
 

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -126,8 +126,6 @@ class Micrograph:
         # Generate MotionCor command
         command = [
             motioncor_executable(),
-            "-OutMrc",
-            str(output_dir.absolute()) + os.path.sep,
             "-FtBin",
             str(binning),
         ]
@@ -170,14 +168,17 @@ class Micrograph:
             command += ["-Group", str(group)]
 
         # Now, correct every movie separately, since -Serial 1 causes issues
-
         for movie in movies:
-            tempdir.joinpath(movie.path.name).symlink_to(movie.path.absolute())
 
             if movie.is_mrc:
                 command_temp = command + ["-InMrc", movie.path.absolute()]
             elif movie.is_tiff:
                 command_temp = command + ["-InTiff", movie.path.absolute()]
+
+            command_temp += ["-OutMrc",
+                             str(output_dir.absolute()) +
+                             os.path.sep +
+                             movie.path.with_suffix(".mrc".name)]
 
             with open(join(output_dir, "motioncor2.log"), "a") as out, open(
                 join(output_dir, "motioncor2.err"), "a"

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -241,7 +241,7 @@ class Micrograph:
 
 
 def motioncor2_executable() -> Optional[str]:
-    """Return MotionCor2 executable.
+    """Return MotionCor2/3 executable.
 
     Path can be set with one of the following ways (in order of priority):
     1. Setting the MOTIONCOR2_EXECUTABLE variable to the full path of the executable
@@ -253,27 +253,13 @@ def motioncor2_executable() -> Optional[str]:
             return mc2_exe
         else:
             raise FileNotFoundError(
-                f'Variable for MC2 is set to "{mc2_exe}", but file is missing.'
+                f'Variable for MotionCorX is set to "{mc2_exe}", but file is missing.'
             )
-    return shutil.which("motioncor2")
 
-
-def aretomo_executable() -> Optional[str]:
-    """Return AreTomo executable.
-
-    Path can be set with one of the following ways (in order of priority):
-    1. Setting the ARETOMO_EXECUTABLE variable to the full path of the executable
-    2. Putting the appropriate executable into the PATH and renaming it to "aretomo"
-    """
-    if "ARETOMO_EXECUTABLE" in os.environ:
-        aretomo_exe = os.environ["ARETOMO_EXECUTABLE"]
-        if isfile(aretomo_exe):
-            return aretomo_exe
-        else:
-            raise FileNotFoundError(
-                f'Variable for AreTomo is set to "{aretomo_exe}", but file is missing.'
-            )
-    return shutil.which("AreTomo")
+    elif shutil.which("MotionCor3") is not None:
+        return shutil.which("MotionCor3")
+    else:
+        return shutil.which("MotionCor2")
 
 
 def sem2mc2(RotationAndFlip: int = 0):

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -178,7 +178,7 @@ class Micrograph:
             command_temp += ["-OutMrc",
                              str(output_dir.absolute()) +
                              os.path.sep +
-                             movie.path.with_suffix(".mrc".name)]
+                             movie.path.with_suffix(".mrc").name]
 
             with open(join(output_dir, "motioncor2.log"), "a") as out, open(
                 join(output_dir, "motioncor2.err"), "a"

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -5,6 +5,7 @@ import subprocess
 from glob import glob
 from os import path
 from pathlib import Path
+from typing import List
 
 import mrcfile
 
@@ -204,7 +205,7 @@ def make_warp_dir(ts: TiltSeries,
     return
 
 
-def batch_parser(input_files: [], batch: bool):
+def batch_parser(input_files: List, batch: bool):
     """Batch-parse tiltseries to work on from textfile."""
     input_files_parsed = []
 

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -298,16 +298,15 @@ def align_with_areTomo(
         patch_x, patch_y = [
             str(round(full_dimensions[0] / 1000)),
             str(round(full_dimensions[1] / 1000))]
-        alignZ = str(round(volz / angpix))
-
-        pretilt = -1 * round(mdocfile.get_start_tilt(mdoc))
+        
+        alignZ = str(round(volz * 10 / angpix))
 
         subprocess.run([aretomo_executable(),
                         '-InMrc', ts.path,
                         '-OutMrc', ali_stack,
                         '-AngFile', tlt_file,
                         '-VolZ', '0',
-                        '-TiltCor', f'0 {pretilt}',
+                        '-TiltCor', '0',
                         '-AlignZ', alignZ] +
                        (['-Gpu'] + [str(i) for i in gpu_id]) +
                        (['-Patch', patch_x, patch_y] if local else []),

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -215,7 +215,8 @@ def aretomo_executable() -> Optional[str]:
 
     Path can be set with one of the following ways (in order of priority):
     1. Setting the ARETOMO_EXECUTABLE variable to the full path of the executable
-    2. Putting the appropriate executable into the PATH and renaming it to "AreTomo"
+    2. Putting "AreTomo" in PATH.
+    3. Putting "AreTomo2" in PATH.
     """
     if "ARETOMO_EXECUTABLE" in os.environ:
         aretomo_exe = os.environ["ARETOMO_EXECUTABLE"]
@@ -223,12 +224,14 @@ def aretomo_executable() -> Optional[str]:
             return aretomo_exe
         else:
             raise FileNotFoundError(
-                f'Variable for AreTomo is set to "{aretomo_exe}", but file is missing.'
+                f'ARETOMO_EXECUTABLE is set to "{aretomo_exe}", but file is missing.'
             )
+    elif shutil.which("AreTomo") is not None:
+        return shutil.which("AreTomo")
     elif shutil.which("AreTomo2") is not None:
         return shutil.which("AreTomo2")
     else:
-        return shutil.which("AreTomo")
+        raise FileNotFoundError("AreTomo not found. Check README.md for setup info.")
 
 
 #TODO: implement binning using -OutBin X
@@ -615,7 +618,7 @@ def parse_ctfplotter(file: Path):
     return df_file
 
 
-def write_ctfplotter(df: pd.DataFrame(), file: Path):
+def write_ctfplotter(df: pd.DataFrame, file: Path):
     """Writes Pandas dataframe as ctfplotter .defocus file."""
     # Somehow this header is present in ctfplotter files, so also add here.
     header = pd.DataFrame(['1', '0', '0.0', '0.0', '0.0', '3']).T
@@ -674,7 +677,7 @@ def parse_darkimgs(ts: TiltSeries):
     return dark_tilts
 
 
-def convert_input_to_TiltSeries(input_files:[]):
+def convert_input_to_TiltSeries(input_files: List[Path]):
     """Takes list of input files or folders from Click.
 
     Returns list of TiltSeries objects with or without split frames.

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -211,11 +211,11 @@ class TiltSeries:
 
 
 def aretomo_executable() -> Optional[str]:
-    """Return AreTomo executable.
+    """Return AreTomo1/2 executable.
 
     Path can be set with one of the following ways (in order of priority):
     1. Setting the ARETOMO_EXECUTABLE variable to the full path of the executable
-    2. Putting the appropriate executable into the PATH and renaming it to "aretomo"
+    2. Putting the appropriate executable into the PATH and renaming it to "AreTomo"
     """
     if "ARETOMO_EXECUTABLE" in os.environ:
         aretomo_exe = os.environ["ARETOMO_EXECUTABLE"]
@@ -225,9 +225,13 @@ def aretomo_executable() -> Optional[str]:
             raise FileNotFoundError(
                 f'Variable for AreTomo is set to "{aretomo_exe}", but file is missing.'
             )
-    return shutil.which("AreTomo")
+    elif shutil.which("AreTomo2") is not None:
+        return shutil.which("AreTomo2")
+    else:
+        return shutil.which("AreTomo")
 
 
+#TODO: implement binning using -OutBin X
 def align_with_areTomo(
     ts: TiltSeries, local: bool, previous: bool, do_evn_odd: bool, gpu: str,
         volz: int = 250):

--- a/tomotools/utils/tomogram.py
+++ b/tomotools/utils/tomogram.py
@@ -3,7 +3,7 @@ import subprocess
 from glob import glob
 from os import path
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import mrcfile
 
@@ -83,7 +83,7 @@ class Tomogram:
         [full_reconstruction_y,full_reconstruction_x] = tiltseries.dimZYX[1:3]
 
         # Bring stack to desired binning level
-        
+
         # TODO: skip here if passed pre-binned aligned stack
         if bin != 1:
             binned_stack = tiltseries.path.with_name(
@@ -284,7 +284,7 @@ class Tomogram:
     @staticmethod
     def from_tiltseries_3dctf(tiltseries: TiltSeries, binning=1,
                               thickness=3000, z_slices_nm=25,
-                              fullimage: [] = None) -> 'Tomogram':
+                              fullimage: Optional[List] = None) -> 'Tomogram':
         """
         Calculate Tomogram with imod ctf3d.
 
@@ -371,7 +371,7 @@ def find_Tomogram_halves(tomo: Tomogram, split_dir: Optional[Path] = None):
     else:
         return tomo
 
-def convert_input_to_Tomogram(input_files:[]):
+def convert_input_to_Tomogram(input_files: List[Path]):
     """Takes list of input files or folders from Click.
 
     Returns list of Tomogram objects with or without split reconstructions.

--- a/tomotools/utils/tomogram.py
+++ b/tomotools/utils/tomogram.py
@@ -83,6 +83,8 @@ class Tomogram:
         [full_reconstruction_y,full_reconstruction_x] = tiltseries.dimZYX[1:3]
 
         # Bring stack to desired binning level
+        
+        # TODO: skip here if passed pre-binned aligned stack
         if bin != 1:
             binned_stack = tiltseries.path.with_name(
                 f'{tiltseries.path.stem}_bin_{bin}.mrc')


### PR DESCRIPTION
As far as I can tell, AreTomo2 and MotionCor3 are basically drop-in replacements for AreTomo / MotionCor2. As we've had some issues with either on newer GPUs, I'm changing the functions finding them and the README to also find the newer versions. 
Also, I will implement it so that the binned stack is created directly during alignment, and then just reconstructed later. 

- [x] Changed aretomo_executable and motioncor_executable functions
- [x] Changed readme
- [x] AreTomo2 seems to be case-sensitive (AreTomo and aretomo behave the same), edit in function and README
- [x] Make sure that MC3 correctly handles tifs 
- [x] Testing