### PR TITLE
Fixed export to Warp with and without frames

### DIFF
--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -203,10 +203,18 @@ def reconstruct_3dctf(thickness, bin, input_files):
 
     print(f'Found {len(input_ts)} TiltSeries to work on. \n')
 
+    # First, check whether all defocus files are there
+    for ts_in in input_ts:
+        # Test, whether .defocus file is found
+        if not path.isfile(ts_in.path.with_suffix(".defocus")):
+            run_ctfplotter(ts_in, True)
+
+    print('All defocus files found or created.')
+
     for ts_in in input_ts:
 
         print(f'Now working on {ts_in.path}.')
-
+        
         # Test whether imod alignment found
         if path.isfile(ts_in.path.with_suffix(".xf")):
             ts = ts_in

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -34,17 +34,19 @@ def fit_ctf(input_files):
               help="Project is for WarpTools 2.x, not Warp 1.x.")
 @click.option('-n', '--name', default='warp', show_default=True,
               help="Warp working directory will be created as project_dir/name.")
-@click.option('--ensure-frames', is_flag=True, default=False, show_default=True,
-              help="Ensure that the frames for each tilt image are exported.")
-@click.option('--frames-dir', default=None, show_default=True,
-              type=click.Path(exists=True, file_okay=False, dir_okay=True),
+@click.option('--include-frames/--skip-frames', is_flag=True,
+              default=False,
+              show_default=True,
+              help="Export also frames for each tilt.")
+@click.option('--frames-dir', default="~", show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True),
               help="Directory containing the original frames.")
 @click.argument('input_files', nargs=-1)
 @click.argument('project_dir', nargs=1)
 def imod2warp(batch_input,
               v2,
               name,
-              ensure_frames,
+              include_frames,
               frames_dir,
               input_files,
               project_dir):
@@ -98,7 +100,7 @@ def imod2warp(batch_input,
         sta_util.make_warp_dir(ts,
                                out_dir,
                                frames_dir = frames_dir,
-                               ensure_frames = ensure_frames,
+                               ensure_frames = include_frames,
                                imod = True,
                                v2 = v2)
 
@@ -112,17 +114,19 @@ def imod2warp(batch_input,
               help="Project is for WarpTools 2.x, not Warp 1.x.")
 @click.option('-n', '--name', default='warp', show_default=True,
               help="Warp working directory will be created as project_dir/name.")
-@click.option('--ensure-frames', is_flag=True, default=False, show_default=True,
-              help="Ensure that the frames for each tilt image are exported.")
-@click.option('--frames-dir', default=None, show_default=True,
-              type=click.Path(exists=True, file_okay=False, dir_okay=True),
+@click.option('--include-frames--skip-frames/', is_flag=True,
+              default=False,
+              show_default=True,
+              help="Export also frames for each tilt.")
+@click.option('--frames-dir', default="~", show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True),
               help="Directory containing the original frames.")
 @click.argument('input_files', nargs=-1)
 @click.argument('project_dir', nargs=1)
 def aretomo2warp(batch_input,
                  v2,
                  name,
-                 ensure_frames,
+                 include_frames,
                  frames_dir,
                  input_files,
                  project_dir):
@@ -179,7 +183,7 @@ def aretomo2warp(batch_input,
         sta_util.make_warp_dir(ts_out_imod,
                                out_dir,
                                frames_dir = frames_dir,
-                               ensure_frames = ensure_frames,
+                               ensure_frames = include_frames,
                                imod = False,
                                v2 = v2)
 

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -114,7 +114,7 @@ def imod2warp(batch_input,
               help="Project is for WarpTools 2.x, not Warp 1.x.")
 @click.option('-n', '--name', default='warp', show_default=True,
               help="Warp working directory will be created as project_dir/name.")
-@click.option('--include-frames--skip-frames/', is_flag=True,
+@click.option('--include-frames/--skip-frames', is_flag=True,
               default=False,
               show_default=True,
               help="Export also frames for each tilt.")

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -214,7 +214,7 @@ def reconstruct_3dctf(thickness, bin, input_files):
     for ts_in in input_ts:
 
         print(f'Now working on {ts_in.path}.')
-        
+
         # Test whether imod alignment found
         if path.isfile(ts_in.path.with_suffix(".xf")):
             ts = ts_in

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -32,13 +32,6 @@ def aretomo_export(ts: TiltSeries):
 
     aln_file = ts.path.with_suffix('.aln')
 
-    if path.isfile(ts.path.with_suffix('.tlt')):
-        tlt_file = ts.path.with_suffix('.tlt')
-    elif path.isfile(ts.path.with_suffix('.rawtlt')):
-        tlt_file = ts.path.with_suffix('.rawtlt')
-    else:
-        raise FileNotFoundError(f'No tilt file found for {ts.stem}!')
-
     ali_stack = ts.path.with_name(f'{ts.path.stem}_ali.mrc')
 
     imod_dir = path.join(ts.path.parent, (ali_stack.stem + "_Imod"))
@@ -67,7 +60,6 @@ def aretomo_export(ts: TiltSeries):
         subprocess.run([aretomo_executable(),
                     '-InMrc', ts.path,
                     '-OutMrc', ali_stack,
-                    '-AngFile', tlt_file,
                     '-AlnFile', aln_file,
                     '-TiltCor', '0',
                     '-VolZ', '0',

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -31,7 +31,14 @@ def aretomo_export(ts: TiltSeries):
         labels = mrc.get_labels()
 
     aln_file = ts.path.with_suffix('.aln')
-    tlt_file = ts.path.with_suffix('.tlt')
+    
+    if path.isfile(ts.path.with_suffix('.tlt')):
+        tlt_file = ts.path.with_suffix('.tlt')
+    elif path.isfile(ts.path.with_suffix('.rawtlt')):
+        tlt_file = ts.path.with_suffix('.rawtlt')
+    else:
+        raise FileNotFoundError(f'No tilt file found for {ts.stem}!')
+    
     ali_stack = ts.path.with_name(f'{ts.path.stem}_ali.mrc')
 
     imod_dir = path.join(ts.path.parent, (ali_stack.stem + "_Imod"))

--- a/tomotools/utils/sta_util.py
+++ b/tomotools/utils/sta_util.py
@@ -31,14 +31,14 @@ def aretomo_export(ts: TiltSeries):
         labels = mrc.get_labels()
 
     aln_file = ts.path.with_suffix('.aln')
-    
+
     if path.isfile(ts.path.with_suffix('.tlt')):
         tlt_file = ts.path.with_suffix('.tlt')
     elif path.isfile(ts.path.with_suffix('.rawtlt')):
         tlt_file = ts.path.with_suffix('.rawtlt')
     else:
         raise FileNotFoundError(f'No tilt file found for {ts.stem}!')
-    
+
     ali_stack = ts.path.with_name(f'{ts.path.stem}_ali.mrc')
 
     imod_dir = path.join(ts.path.parent, (ali_stack.stem + "_Imod"))

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -561,10 +561,17 @@ def run_ctfplotter(ts: TiltSeries, overwrite: bool):
         kV = 300
         cs = 2.7
 
+        if path.isfile(ts.path.with_suffix('.tlt')):
+            tlt_file = ts.path.with_suffix('.tlt')
+        elif path.isfile(ts.path.with_name(f'{ts.path.stem}_ali.tlt')):
+            tlt_file = ts.path.with_name(f'{ts.path.stem}_ali.tlt')
+        else:
+            tlt_file = ts.path.with_suffix('.rawtlt')
+
         with open(path.join(ts.path.parent, 'ctfplotter.log'), 'a') as out:
             subprocess.run(['ctfplotter',
                             '-InputStack', ts.path,
-                            '-angleFn', ts.path.with_suffix('.tlt'),
+                            '-angleFn', tlt_file,
                             '-defFn', ts.path.with_name(
                                 f'{ts.path.stem}.defocus'),
                             '-pixelSize', str(nmpix),


### PR DESCRIPTION
- now uses explicit flag for whether to include frames for warp export
- now also finds `.rawtlt` files in defocus estimation etc. 