### PR TITLE
Tomo5 Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "Tomotools"
 description = "Scripts to make cryo-electron tomography a bit easier."
 readme = "README.md"
-version = "0.4.5"
+version = "0.4.6"
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "None so far"}
 authors = [
   {email = "moritz.wachsmuth@bioquant.uni-heidelberg.de", name = "Moritz Wachsmuth-Melm"},
-  {email = "b.wimmer@bioc.uzh.ch", name = "Benedikt Wimmer"},
+  {email = "wimmer@stanford.edu", name = "Benedikt Wimmer"},
 ]
 dependencies = [
     "Click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ cryocare = [
 dev = [
     "pytest",
     "ruff",
-    "tomotools-testfiles-lfs@git+https://github.com/tomotools/tomotools-testfiles-lfs.git"
 ]
 
 [project.scripts]

--- a/tomotools/__init__.py
+++ b/tomotools/__init__.py
@@ -1,14 +1,22 @@
 """Wrapper for tomotools."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 import click
 
 from .commands import commands
 
 
+def _get_version():
+    try:
+        return version("tomotools")
+    except PackageNotFoundError:
+        return "unknown"
+
 @click.group()
 def tomotools():
     """Scripts for cryo-ET data processing."""
-    click.echo("Tomotools version 0.4.5 \n")
+    click.echo(f"Tomotools version {_get_version()} \n")
 
 
 for command in commands:

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -133,6 +133,12 @@ def blend_montages(cpus, input_files, output_dir):
     help="Pass ExposureDose per tilt to override value in mdoc file.",
 )
 @click.option(
+    "--axisangle",
+    type=float,
+    default=None,
+    help="Pass TiltAxisAngle to override value in header.",
+)
+@click.option(
     "--stack/--nostack",
     is_flag=True,
     default=True,
@@ -152,6 +158,7 @@ def preprocess(
     gpu,
     patch,
     exposuredose,
+    axisangle,
     stack,
     input_files,
     output_dir,
@@ -339,6 +346,10 @@ def preprocess(
                 overwrite_dose=exposuredose
             )
             shutil.rmtree(frames_corrected_dir)
+
+            if axisangle is not None:
+                tilt_series._update_axis_angle(axisangle)
+
             print(f'Successfully created {tilt_series.path}. \n')
 
         else:
@@ -616,3 +627,27 @@ def reconstruct(
 
         tiltseries_dosefiltered.delete_files(delete_mdoc=False)
         print("\n")
+
+@click.command()
+@click.option(
+    "--override_angle",
+    type=float,
+    help="New tilt axis angle to store in header.",
+)
+@click.argument("input_files", nargs=-1, type=click.Path(exists=True))
+def fix_header_angle(
+    override_angle,
+    input_files,
+):
+    """Update TiltAxisAngle in mrc header.
+
+    Sometimes needed for Tomo5-style tomograms.
+    """
+    # Iterate over the tiltseries objects and align and reconstruct
+    input_ts = convert_input_to_TiltSeries(input_files)
+
+    for tiltseries in input_ts:
+
+        tiltseries._update_axis_angle(override_angle)
+
+        print(f"\nSet angle in {tiltseries.path.name} to {override_angle}.")

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -336,7 +336,7 @@ def preprocess(
 
             # Else, add the .mrc (Tomo5-style) to the output file
             else:
-                output_file = output_dir / input_file.mdoc.with_suffix(".mrc")
+                output_file = output_dir / f'{input_file.mdoc.stem}.mrc'
 
             tilt_series = TiltSeries.from_micrographs(
                 micrographs,

--- a/tomotools/commands/serialem.py
+++ b/tomotools/commands/serialem.py
@@ -11,7 +11,7 @@ from tomotools.utils.serialem_navigator import SEMNavigator
 def semnavigator(path):
     """Open a SerialEM navigator (.nav) file in a small graphical browser."""
     nav = SEMNavigator.read(path)
-    fig, ax = plt.subplots()
+    _, ax = plt.subplots()
     all_ptsx, all_ptsy = [], []
     for item in nav.items:
         ptsx_str, ptsy_str = item.get("PtsX"), item.get("PtsY")
@@ -32,3 +32,5 @@ def semnavigator(path):
     ax.set_xlim(min(all_ptsx) * 1.1, max(all_ptsx) * 1.1)
     ax.set_ylim(min(all_ptsy) * 1.1, max(all_ptsy) * 1.1)
     plt.show()
+
+    return

--- a/tomotools/commands/sta_preparation.py
+++ b/tomotools/commands/sta_preparation.py
@@ -222,13 +222,11 @@ def reconstruct_3dctf(thickness, bin, input_files):
         # Test whether imod alignment found
         if path.isfile(ts_in.path.with_suffix(".xf")):
             ts = ts_in
-            aretomo = False
 
         # Test whether AreTomo alignment found
         elif path.isfile(ts_in.path.with_suffix(".aln")):
             ts = sta_util.aretomo_export(ts_in)
             sta_util.ctfplotter_aretomo_export(ts_in)
-            aretomo = True
 
         else:
             print(f"No previous alignments found for {ts_in.path}.")
@@ -255,13 +253,10 @@ def reconstruct_3dctf(thickness, bin, input_files):
             ts_ali_filt, binning=bin, thickness=thickness,
             z_slices_nm=25, fullimage=[dim_x,dim_y])
 
-        # Link reconstruction back to main dir, in case AreTomo alignments are used
-        if aretomo:
-            os.symlink(rec.path.absolute(),
-                       ts_in.path.parent / f'{ts_in.path.stem}_3dctf_bin{bin}.mrc')
-        else:
-            os.rename(rec.path.absolute(),
-                      ts_in.path.parent / f'{ts_in.path.stem}_3dctf_bin{bin}.mrc')
+        # Move / rename reconstruction
+        os.rename(rec.path.absolute(),
+                  ts_in.path.parent.absolute() /
+                  f'{ts_in.path.stem}_3dctf_bin{bin}.mrc')
 
         print('\n')
 

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -1,3 +1,4 @@
+
 import os
 import shutil
 import subprocess
@@ -62,100 +63,46 @@ class Micrograph:
         gpu: Optional[str] = None,
     ) -> "List[Micrograph]":
         """Create micrograph from a list of movies using MotionCor."""
-        # TODO: Reduce complexity C901
-
         tempdir = output_dir.joinpath("motioncor2_temp")
         tempdir.mkdir(parents=True)
-        #gain_ref_dm4 = None
-        #gain_ref_mrc = None
 
-        # If override_gainref is given, keep
+        # Find gain reference
+        # 1. Use override_gainref if given
+        # 2. Otherwise, check mdoc for gain reference
         if override_gainref is not None:
             override_gainref = Path(override_gainref)
-
         elif override_gainref is None and movies[0].mdoc is not None:
             # Check if there is a subframe mdoc and if it contains a gain reference path
             gain_refs = {movie.mdoc["framesets"][0].get("GainReference", None)
-                         for movie in movies}
-
-            if len(gain_refs) != 1:
-                raise Exception(
-                    f'Only 0 or 1 gainref supported, {len(gain_refs)} found in mdoc.'
-                )
-            override_gainref = gain_refs.pop()
-            if override_gainref is not None:
+                         for movie in movies if movie.mdoc is not None}
+            gain_refs.discard(None)
+            if len(gain_refs) > 1:
+                raise Exception('Found multiple gain references, only one is supported')
+            elif len(gain_refs) == 1:
                 # The gain ref should be in the same folder as the input file(s)
                 # Check if it's there.
-                override_gainref = movies[0].path.parent / override_gainref
-                if not override_gainref.is_file():
+                override_gainref = gain_refs.pop()
+                override_gainref = movies[0].path.parent / override_gainref  # pyright: ignore[reportOperatorIssue]
+                if not override_gainref.is_file():  # pyright: ignore[reportOptionalMemberAccess]
                     raise FileNotFoundError(
                         f"Couldn't find gain reference at {override_gainref}, aborting"
                     )
 
-        def _conv_dm_mrc(gain_in, out_path):
-
-            temp_gain = output_dir.joinpath("motioncor2_gain")
-            temp_gain.mkdir()
-            gain_out = temp_gain.joinpath(gain_in.stem + ".mrc")
-            print(
-                f"Found gain reference {gain_in}, converting to {gain_out}"
-            )
-
-            subprocess.run(["dm2mrc", gain_in, gain_out],
-                           stdout=subprocess.DEVNULL)
-
-            return gain_out
-
-        def _conv_tiff_mrc(gain_in, out_path):
-
-            temp_gain = output_dir.joinpath("motioncor2_gain")
-            temp_gain.mkdir()
-            gain_out = temp_gain.joinpath(gain_in.stem + ".mrc")
-            print(
-                f"Found gain reference {gain_in}, converting to {gain_out}"
-            )
-
-            subprocess.run(["tif2mrc", gain_in, gain_out],
-                           stdout=subprocess.DEVNULL)
-
-            return gain_out
-
-        # Check file type, then directly convert to mrc
+        # Convert gain reference to mrc if needed
         if override_gainref is None:
             gain_ref_mrc = None
-        elif override_gainref.suffix == ".mrc":
-            gain_ref_mrc = override_gainref
-
-        elif override_gainref.suffix == ".dm4":
-            gain_ref_mrc = _conv_dm_mrc(override_gainref,
-                                        output_dir)
-
-        elif override_gainref.suffix in [".tif",".tiff"]:
-            gain_ref_mrc = _conv_tiff_mrc(override_gainref,
-                                          output_dir)
-        elif override_gainref.suffix == ".gain":
-            gain_ref_mrc = _conv_tiff_mrc(override_gainref,
-                                          output_dir)
-            print('Gain reference as .gain format. Assuming newer Falcon camera!')
-
-        else:
-            raise AttributeError(
-                "Gain reference can only be in .tif(f), .dm4 or .mrc format!"
+            print(
+                "No gainref is given or found, continuing without gain correction."
             )
-
-
-        if gain_ref_mrc is not None:
+        else:
+            gain_ref_mrc = _ensure_gainref_mrc(override_gainref, output_dir)
             if not gain_ref_mrc.is_file():
                 raise FileNotFoundError(
                     f"The GainRef file {gain_ref_mrc} doesn't exist!"
                 )
             print(f"Using gainref file {gain_ref_mrc}")
-        else:
-            print(
-                "No gainref is given or found, continuing without gain correction."
-            )
 
-        # Generate MotionCor command
+        # Build and run MotionCor command
         command = [
             motioncor_executable(),
             "-FtBin",
@@ -180,7 +127,7 @@ class Micrograph:
         if mcrot is not None and mcflip is not None:
             command += ["-RotGain", str(mcrot), "-FlipGain", str(mcflip)]
 
-        if (override_gainref.suffix == '.dm4' and
+        if (override_gainref is not None and override_gainref.suffix == '.dm4' and
             check_defects(override_gainref) is not None):
             command += [
                 "-DefectMap",
@@ -296,6 +243,26 @@ def motioncor_executable() -> Optional[str]:
                 'MotionCor not found. Check README.md for setup info.'
             )
 
+def _ensure_gainref_mrc(gain_ref: Path, output_dir: Path) -> Path:
+    temp_gain = output_dir / "motioncor2_gain"
+    temp_gain.mkdir()
+    gain_out = temp_gain / (gain_ref.with_suffix(".mrc").name)
+    print(
+        f"Found gain reference {gain_ref}, converting to {gain_out}"
+    )
+    if gain_ref.suffix == ".mrc":
+        gain_out = gain_ref
+    elif gain_ref.suffix == ".dm4":
+        subprocess.run(["dm2mrc", gain_ref, gain_out],
+                        stdout=subprocess.DEVNULL)
+    elif gain_ref.suffix in [".tif", ".tiff", ".gain"]:
+        subprocess.run(["tif2mrc", gain_ref, gain_out],
+                        stdout=subprocess.DEVNULL)
+    else:
+        raise AttributeError(
+            "Gain reference can only be in .tif(f) or .dm4 format!"
+        )
+    return gain_out
 
 def sem2mc2(RotationAndFlip: int = 0):
     """Read RotationAndFlip for MotionCor2.

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -252,7 +252,7 @@ class Micrograph:
                         "Gain reference was specified, but not applied by MotionCor."
                     )
 
-        if  os.isdir(output_dir.joinpath("motioncor2_gain")):
+        if  os.path.isdir(output_dir.joinpath("motioncor2_gain")):
             shutil.rmtree(output_dir.joinpath("motioncor2_gain"))
 
         output_micrographs = [

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -66,22 +66,14 @@ class Micrograph:
 
         tempdir = output_dir.joinpath("motioncor2_temp")
         tempdir.mkdir(parents=True)
-        gain_ref_dm4 = None
-        gain_ref_mrc = None
+        #gain_ref_dm4 = None
+        #gain_ref_mrc = None
 
-        # If override_gainref is given, check if it is already mrc
-        # Otherwise, convert.
+        # If override_gainref is given, keep
         if override_gainref is not None:
             override_gainref = Path(override_gainref)
-            if override_gainref.suffix == ".dm4":
-                gain_ref_dm4 = override_gainref
-            elif override_gainref.suffix == ".mrc":
-                gain_ref_mrc = override_gainref
-            else:
-                raise AttributeError(
-                    "Gain reference can only be in .dm4 or .mrc format!"
-                )
-        elif movies[0].mdoc is not None:
+
+        elif override_gainref is None and movies[0].mdoc is not None:
             # Check if there is a subframe mdoc and if it contains a gain reference path
             gain_refs = {movie.mdoc["framesets"][0].get("GainReference", None)
                          for movie in movies}
@@ -90,27 +82,67 @@ class Micrograph:
                 raise Exception(
                     f'Only 0 or 1 gainref supported, {len(gain_refs)} found in mdoc.'
                 )
-            gain_ref_dm4 = gain_refs.pop()
-            if gain_ref_dm4 is not None:
+            override_gainref = gain_refs.pop()
+            if override_gainref is not None:
                 # The gain ref should be in the same folder as the input file(s)
                 # Check if it's there.
-                gain_ref_dm4 = movies[0].path.parent / gain_ref_dm4
-                if not gain_ref_dm4.is_file():
+                override_gainref = movies[0].path.parent / override_gainref
+                if not override_gainref.is_file():
                     raise FileNotFoundError(
-                        f"Expected gain reference at {gain_ref_dm4}, aborting"
+                        f"Couldn't find gain reference at {override_gainref}, aborting"
                     )
 
-        if gain_ref_dm4 is not None and gain_ref_mrc is None:
-            # The gain ref is saved in dm4 format, convert to MRC for MotionCor2
-            # Write to a separate directory to keep it away from MC2.
+        def _conv_dm_mrc(gain_in, out_path):
+
             temp_gain = output_dir.joinpath("motioncor2_gain")
             temp_gain.mkdir()
-            gain_ref_mrc = temp_gain.joinpath(gain_ref_dm4.stem + ".mrc")
+            gain_out = temp_gain.joinpath(gain_in.stem + ".mrc")
             print(
-                f"Found gain reference {gain_ref_dm4}, converting to {gain_ref_mrc}"
+                f"Found gain reference {gain_in}, converting to {gain_out}"
             )
-            subprocess.run(["dm2mrc", gain_ref_dm4, gain_ref_mrc],
+
+            subprocess.run(["dm2mrc", gain_in, gain_out],
                            stdout=subprocess.DEVNULL)
+
+            return gain_out
+
+        def _conv_tiff_mrc(gain_in, out_path):
+
+            temp_gain = output_dir.joinpath("motioncor2_gain")
+            temp_gain.mkdir()
+            gain_out = temp_gain.joinpath(gain_in.stem + ".mrc")
+            print(
+                f"Found gain reference {gain_in}, converting to {gain_out}"
+            )
+
+            subprocess.run(["tif2mrc", gain_in, gain_out],
+                           stdout=subprocess.DEVNULL)
+
+            return gain_out
+
+        # Check file type, then directly convert to mrc
+        if override_gainref is None:
+            gain_ref_mrc = None
+        elif override_gainref.suffix == ".mrc":
+            gain_ref_mrc = override_gainref
+
+        elif override_gainref.suffix == ".dm4":
+            gain_ref_mrc = _conv_dm_mrc(override_gainref,
+                                        output_dir)
+
+        elif override_gainref.suffix in [".tif",".tiff"]:
+            gain_ref_mrc = _conv_tiff_mrc(override_gainref,
+                                          output_dir)
+        elif override_gainref.suffix == ".gain":
+            gain_ref_mrc = _conv_tiff_mrc(override_gainref,
+                                          output_dir)
+            print('Gain reference as .gain format. Assuming newer Falcon camera!')
+
+        else:
+            raise AttributeError(
+                "Gain reference can only be in .tif(f), .dm4 or .mrc format!"
+            )
+
 
         if gain_ref_mrc is not None:
             if not gain_ref_mrc.is_file():
@@ -148,10 +180,11 @@ class Micrograph:
         if mcrot is not None and mcflip is not None:
             command += ["-RotGain", str(mcrot), "-FlipGain", str(mcflip)]
 
-        if gain_ref_dm4 is not None and check_defects(gain_ref_dm4) is not None:
+        if (override_gainref.suffix == '.dm4' and
+            check_defects(override_gainref) is not None):
             command += [
                 "-DefectMap",
-                defects_tif(gain_ref_dm4, tempdir, movies[0].path).absolute(),
+                defects_tif(override_gainref, tempdir, movies[0].path).absolute(),
             ]
 
         # Patch alignment takes two groupings, for global and local alignments.
@@ -219,8 +252,8 @@ class Micrograph:
                         "Gain reference was specified, but not applied by MotionCor."
                     )
 
-        if gain_ref_dm4 is not None:
-            shutil.rmtree(temp_gain)
+        if  os.isdir(output_dir.joinpath("motioncor2_gain")):
+            shutil.rmtree(output_dir.joinpath("motioncor2_gain"))
 
         output_micrographs = [
             Micrograph(
@@ -321,3 +354,10 @@ def defects_tif(gainref, tempdir, template):
     subprocess.run(["clip", "defect", "-D", defects_txt, template, defects_tif])
     print(f"Found and converted defects file {defects_tif}")
     return defects_tif
+
+def make_mrc_gainref(gainref):
+    """Convert DM4 or TIF(F) GainRef to MRC.
+
+    Checks for existence of converted GainRef.
+    """
+    pass

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -27,10 +27,11 @@ class TiltSeries:
 
     def __init__(self, ts_path: Path):
         if ts_path is None:
-            pass
+            self.path = None
         elif not path.isfile(ts_path):
             raise FileNotFoundError(f"File not found: {ts_path}")
-        self.path: Path = Path(ts_path)
+        else:
+            self.path: Path = Path(ts_path)
         self.mdoc: Path = Path(f"{ts_path}.mdoc")
         self.is_split: bool = False
         self.evn_path: Optional[Path] = None

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -1,6 +1,7 @@
 import csv
 import math
 import os
+import re
 import shutil
 import subprocess
 from glob import glob
@@ -10,6 +11,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import mrcfile
+import numpy as np
 import pandas as pd
 
 from tomotools.utils import mdocfile, util
@@ -106,10 +108,64 @@ class TiltSeries:
         """Return tilt axis angle from header."""
         if hasattr(self, '_axis_angle'):
             return self._axis_angle
-        with mrcfile.mmap(self.path) as mrc:
+        with mrcfile.open(self.path, header_only=True) as mrc:
+
+            # Check SerialEM-type header spelling first
             header = str(mrc.header).split('Tilt axis angle = ', 1)
+
+            if len(header) == 1:
+                # Otherwise, try Tomo5 writing
+                header = str(mrc.header).split('TiltAxisAngle = ', 1)
+
+                if len(header) == 1:
+                    raise NotImplementedError("Can't find tilt axis in header.")
+
             self._axis_angle = float(header[1][0:4])
         return self._axis_angle
+
+
+    def _update_axis_angle(self, tilt_axis_angle: float):
+        """Update TiltAxisAngle in header."""
+        with mrcfile.open(self.path, mode = 'r+', header_only = True) as mrc:
+
+            labels = mrc.header.label
+
+            # Tomo5 Notation
+            if 'TiltAxisAngle' in str(labels):
+                # Regex breakdown:
+                # (TiltAxisAngle\s*=\s*) ->
+                # Group 1: The key and the equals sign (with any spacing)
+                # [+-]?\d*\.?\d+ ->
+                # The number (handles signs, integers, and decimals)
+                pattern = rb"(TiltAxisAngle\s*=\s*)[+-]?\d*\.?\d+"
+
+            # SerialEM Notation
+            elif 'Tilt axis angle' in str(labels):
+                pattern = rb"(Tilt axis angle\s*=\s*)[+-]?\d*\.?\d+"
+
+            # Otherwise, this item should be added new.
+            else:
+                empty_indices = np.where(labels == b'')[0]
+
+                if len(empty_indices) == 0:
+                    idx = labels[-1]
+
+                else:
+                    idx = empty_indices[0]
+
+                labels[idx] = f"TiltAxisAngle = {tilt_axis_angle}".encode()
+
+            replacement = f"\\1 {tilt_axis_angle}".encode()
+
+            # Apply to every element in the array
+            # NumPy automatically handles the S80 padding for the new, shorter strings
+            mrc.header.label = np.array([re.sub(pattern,
+                                                replacement,
+                                                line) for line in labels], dtype='|S80')
+
+            self._axis_angle = tilt_axis_angle
+
+            return
 
     @staticmethod
     def _update_mrc_header_from_mdoc(path: Path, mdoc: dict):
@@ -140,6 +196,7 @@ class TiltSeries:
         mdoc: Optional[dict] = None,
         reorder=False,
         overwrite_titles: Optional[List[str]] = None,
+        overwrite_angles: Optional[float] = None,
         overwrite_dose: Optional[float] = None
     ) -> "TiltSeries":
         """Create TiltSeries from Micrographs, aka run newstack."""
@@ -243,7 +300,7 @@ def aretomo_executable() -> Optional[str]:
 #TODO: implement binning using -OutBin X
 def align_with_areTomo(
     ts: TiltSeries, local: bool, previous: bool, do_evn_odd: bool, gpu: str,
-        volz: int = 250):
+        volz: int = 250, override_axis: Optional[float] = None):
     """Takes a TiltSeries as input and runs AreTomo on it.
 
     Optional: do local alignment.
@@ -308,6 +365,8 @@ def align_with_areTomo(
                         '-VolZ', '0',
                         '-TiltCor', '0',
                         '-AlignZ', alignZ] +
+                       (['-TiltAxis', override_axis]
+                        if override_axis is not None else []) +
                        (['-Gpu'] + [str(i) for i in gpu_id]) +
                        (['-Patch', patch_x, patch_y] if local else []),
                        stdout=subprocess.DEVNULL)
@@ -518,7 +577,9 @@ def align_with_imod(ts: TiltSeries, previous: bool, do_evn_odd: bool, binning = 
                            stdout=subprocess.DEVNULL)
 
             print(f'Aligned {ts.path} and associated EVN/ODD stacks with imod.')
-            return TiltSeries(ali_stack).with_split_files(ali_stack_evn, ali_stack_odd).with_mdoc(orig_mdoc) #noqa: E501
+            return TiltSeries(ali_stack
+                              ).with_split_files(
+                                  ali_stack_evn,ali_stack_odd).with_mdoc(orig_mdoc)
 
         print(f'Finished aligning {ts.path} with imod.')
         return TiltSeries(ali_stack).with_mdoc(orig_mdoc)
@@ -543,8 +604,8 @@ def aln_to_tlt(aln_file: Path):
             else:
                 row_cleaned = [entry for i,
                                entry in enumerate(row) if entry != '']
-                (sec, rot, gmag, tx, ty, smean, sfit,
-                 scale, base, tilt) = row_cleaned
+                (_sec, _rot, _gmag, _tx, _ty, _smean, _sfit,
+                 _scale, _base, tilt) = row_cleaned
 
                 tilts.append(tilt)
 
@@ -681,7 +742,7 @@ def parse_darkimgs(ts: TiltSeries):
                     break
                 elif row[1].startswith('DarkFrame'):
                     row_cleaned = [entry for i, entry in enumerate(row) if entry != '']
-                    (no, title, equal, view, view2, ang) = row_cleaned
+                    (_no, _title, _equal, view, _view2, _ang) = row_cleaned
                     dark_tilts.append(int(view))
                 else:
                     pass

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -108,7 +108,7 @@ class TiltSeries:
         """Return tilt axis angle from header."""
         if hasattr(self, '_axis_angle'):
             return self._axis_angle
-        with mrcfile.open(self.path, header_only=True) as mrc:
+        with mrcfile.mmap(self.path) as mrc:
 
             # Check SerialEM-type header spelling first
             header = str(mrc.header).split('Tilt axis angle = ', 1)
@@ -126,7 +126,7 @@ class TiltSeries:
 
     def _update_axis_angle(self, tilt_axis_angle: float):
         """Update TiltAxisAngle in header."""
-        with mrcfile.open(self.path, mode = 'r+', header_only = True) as mrc:
+        with mrcfile.mmap(self.path, mode = 'r+') as mrc:
 
             labels = mrc.header.label
 

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -30,7 +30,7 @@ class TiltSeries:
             pass
         elif not path.isfile(ts_path):
             raise FileNotFoundError(f"File not found: {ts_path}")
-        self.path: Path = ts_path
+        self.path: Path = Path(ts_path)
         self.mdoc: Path = Path(f"{ts_path}.mdoc")
         self.is_split: bool = False
         self.evn_path: Optional[Path] = None
@@ -382,7 +382,7 @@ def align_with_areTomo(
         os.rename(f"{ts.path}.aln", aln_file)
 
     # Keep compatibility with AreTomo < 1.3, which output the file
-    if not path.isfile(ali_stack.with_suffix('.tlt')):
+    if not path.isfile(ts.path.with_suffix('.tlt')):
         aln_to_tlt(aln_file)
 
     if do_evn_odd and ts.is_split:
@@ -609,7 +609,7 @@ def aln_to_tlt(aln_file: Path):
 
                 tilts.append(tilt)
 
-    tlt_out = aln_file.with_name(f"{aln_file.stem}_ali.tlt")
+    tlt_out = aln_file.with_name(f"{aln_file.stem}.tlt")
 
     with open(tlt_out, mode="w+") as f:
         f.write("\n".join(tilts))
@@ -636,10 +636,10 @@ def run_ctfplotter(ts: TiltSeries, overwrite: bool):
 
         if path.isfile(ts.path.with_suffix('.tlt')):
             tlt_file = ts.path.with_suffix('.tlt')
-        elif path.isfile(ts.path.with_name(f'{ts.path.stem}_ali.tlt')):
-            tlt_file = ts.path.with_name(f'{ts.path.stem}_ali.tlt')
-        else:
+        elif path.isfile(ts.path.with_suffix('.rawtlt')):
             tlt_file = ts.path.with_suffix('.rawtlt')
+        else:
+            raise FileNotFoundError(f'Tlt file not found for {ts.path}.')
 
         with open(path.join(ts.path.parent, 'ctfplotter.log'), 'a') as out:
             subprocess.run(['ctfplotter',


### PR DESCRIPTION
Our new cryo-ET workflow unfortunately involves Tomo5. This PR closes issue #52 and allows setting the proper tilt axis angle in the header of the mrc, either during `tomotools preprocess` or in a separate command. 